### PR TITLE
docs: unify and align the three-language READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
 
 <h3 align="center">EmoLLM</h3>
 
-  <div align="center">
-      简体中文| <a href="README_EN.md" >English</a> | <a href="README_JP.md" >日本語</a>
+  <p align="center">
+  简体中文 | <a href="README_EN.md">English</a> | <a href="README_JP.md">日本語</a>
     <br />
     <br />
     <a href="https://github.com/SmartFlowAI/EmoLLM"><strong>探索本项目的文档 »</strong></a>
@@ -36,7 +36,9 @@
     <a href="https://github.com/SmartFlowAI/EmoLLM/issues">报告Bug</a>
     ·
     <a href="https://github.com/SmartFlowAI/EmoLLM/issues">提出新特性</a>
-  </div>
+  </p>
+
+</p>
 
 <!-- 本篇README.md面向开发者 -->
 
@@ -208,6 +210,7 @@
     - [🎓评测指南](#评测指南)
     - [使用到的框架](#使用到的框架)
       - [如何参与本项目](#如何参与本项目)
+    - [版本控制](#版本控制)
     - [作者（排名不分先后）](#作者排名不分先后)
     - [版权说明](#版权说明)
     - [引用](#引用)
@@ -298,6 +301,10 @@ git clone https://github.com/SmartFlowAI/EmoLLM.git
 5. Open a Pull Request
 
 </details>
+
+### 版本控制
+
+本项目使用 Git 进行版本控制，你可以在仓库中查看当前可用的版本。
 
 ### 作者（排名不分先后）
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -215,6 +215,7 @@ The Model aims to fully understand and promote the mental health of individuals,
     - [Version control](#version-control)
     - [Authors (in no particular order)](#authors-in-no-particular-order)
     - [Copyright Notice](#copyright-notice)
+    - [Citation](#citation)
     - [Acknowledgments](#acknowledgments)
       - [Related Projects](#related-projects)
       - [People](#people)

--- a/README_JP.md
+++ b/README_JP.md
@@ -25,7 +25,7 @@
 <h3 align="center">EmoLLM</h3>
 
   <p align="center">
-  <a href="README.md">简体中文</a> | English | 日本語
+  <a href="README.md">简体中文</a> | <a href="README_EN.md">English</a> | 日本語
     <br />
     <br />
     <a href="https://github.com/SmartFlowAI/EmoLLM"><strong>このプロジェクトのドキュメントを探索する »</strong></a>
@@ -49,20 +49,21 @@
 |         モデル         |       タイプ       | ファイルリンク  | モデルリンク  |
 | :-------------------: | :------: | :------------------------------------------------------------------------------------------------------: |:------: |
 |   Deepseek-R1_14b_int4   |  QLoRA   |  unsloth | [ModelScope](https://www.modelscope.cn/models/haiyangpengai/careyou_7b_16bit_v3_2_qwen14_4bit) |
-|   InternLM2_5_7B_chat   |  QLORA   |  [internlm2_5_chat_7b_qlora_oasst1_e3.py](./xtuner_config/internlm2_5_chat_7b_qlora_oasst1_e3.py) |[ModelScope](https://www.modelscope.cn/models/z342994309/emollm_interlm2_5/)  |
-|   InternLM2_7B_chat   |  QLORA   |  [internlm2_7b_chat_qlora_e3.py](./xtuner_config/internlm2_7b_chat_qlora_e3.py) | [ModelScope](https://modelscope.cn/models/aJupyter/EmoLLM/files) |
+|   InternLM2_5_7B_chat   |  全量微調整   |  [internlm2_5_chat_7b_full.py](./xtuner_config/internlm2_5_chat_7b_full.py) | [OpenXLab](https://openxlab.org.cn/models/detail/chg0901/EmoLLM_V3.0), [ModelScope](https://modelscope.cn/models/chg0901/EmoLLMV3.0) |
+|   InternLM2_5_7B_chat   |  QLoRA   |  [internlm2_5_chat_7b_qlora_oasst1_e3.py](./xtuner_config/internlm2_5_chat_7b_qlora_oasst1_e3.py) |[ModelScope](https://www.modelscope.cn/models/z342994309/emollm_interlm2_5/)  |
+|   InternLM2_7B_chat   |  QLoRA   |  [internlm2_7b_chat_qlora_e3.py](./xtuner_config/internlm2_7b_chat_qlora_e3.py) | [ModelScope](https://modelscope.cn/models/aJupyter/EmoLLM/files) |
 |   InternLM2_7B_chat   | 全量微調整 | [internlm2_chat_7b_full.py](./xtuner_config/internlm2_chat_7b_full.py)  | [OpenXLab](https://openxlab.org.cn/models/detail/ajupyter/EmoLLM_internlm2_7b_full) |
-|   InternLM2_7B_base   |  QLORA   | [internlm2_7b_base_qlora_e10_M_1e4_32_64.py](./xtuner_config/internlm2_7b_base_qlora_e10_M_1e4_32_64.py) |[OpenXLab](https://openxlab.org.cn/models/detail/chg0901/EmoLLM-InternLM7B-base-10e), [ModelScope](https://www.modelscope.cn/models/chg0901/EmoLLM-InternLM7B-base-10e/summary) |
+|   InternLM2_7B_base   |  QLoRA   | [internlm2_7b_base_qlora_e10_M_1e4_32_64.py](./xtuner_config/internlm2_7b_base_qlora_e10_M_1e4_32_64.py) |[OpenXLab](https://openxlab.org.cn/models/detail/chg0901/EmoLLM-InternLM7B-base-10e), [ModelScope](https://www.modelscope.cn/models/chg0901/EmoLLM-InternLM7B-base-10e/summary) |
 |  InternLM2_1_8B_chat  | 全量微調整 |  [internlm2_1_8b_full_alpaca_e3.py](./xtuner_config/internlm2_1_8b_full_alpaca_e3.py)  | [OpenXLab](https://openxlab.org.cn/models/detail/ajupyter/EmoLLM_internlm2_1_8b_full/tree/main), [ModelScope](https://modelscope.cn/models/aJupyter/EmoLLM_PT_InternLM1.8B-chat/files) |
-|  InternLM2_20B_chat   |   LORA   |[internlm2_20b_chat_lora_alpaca_e3.py](./xtuner_config/internlm2_20b_chat_lora_alpaca_e3.py)| |
-|     Qwen_7b_chat      |  QLORA   |  [qwen_7b_chat_qlora_e3.py](./xtuner_config/qwen_7b_chat_qlora_e3.py) | |
+|  InternLM2_20B_chat   |   LoRA   |[internlm2_20b_chat_lora_alpaca_e3.py](./xtuner_config/internlm2_20b_chat_lora_alpaca_e3.py)| |
+|     Qwen_7b_chat      |  QLoRA   |  [qwen_7b_chat_qlora_e3.py](./xtuner_config/qwen_7b_chat_qlora_e3.py) | |
 |   Qwen1_5-0_5B-Chat   | 全量微調整 |   [qwen1_5_0_5_B_full.py](./xtuner_config/qwen1_5_0_5_B_full.py) | [ModelScope](https://www.modelscope.cn/models/aJupyter/EmoLLM_Qwen1_5-0_5B-Chat_full_sft/summary) |
-|  Baichuan2_13B_chat   |  QLORA   |   [baichuan2_13b_chat_qlora_alpaca_e3.py](./xtuner_config/baichuan2_13b_chat_qlora_alpaca_e3.py) | |
-|      ChatGLM3_6B      |   LORA   |   [chatglm3_6b_lora_alpaca_e3.py](./xtuner_config/chatglm3_6b_lora_alpaca_e3.py)  | |
-| DeepSeek MoE_16B_chat |  QLORA   |  [deepseek_moe_16b_chat_qlora_oasst1_e3.py](./xtuner_config/deepseek_moe_16b_chat_qlora_oasst1_e3.py)    | |
-| Mixtral 8x7B_instruct |  QLORA   | [mixtral_8x7b_instruct_qlora_oasst1_e3.py](./xtuner_config/mixtral_8x7b_instruct_qlora_oasst1_e3.py)    | |
-| LLaMA3_8b_instruct    |  QLORA   | [aiwei_llama3_8b_instruct_qlora_e3.py](./xtuner_config/aiwei_llama3_8b_instruct_qlora_e3.py) | [OpenXLab](https://openxlab.org.cn/models/detail/ajupyter/EmoLLM-LLaMA3_8b_instruct_aiwei/tree/main), [ModelScope](https://modelscope.cn/models/aJupyter/EmoLLM-LLaMA3_8b_instruct_aiwei/files) |
-| LLaMA3_8b_instruct    |  QLORA   | [llama3_8b_instruct_qlora_alpaca_e3_M_ruozhi_scM.py](./xtuner_config/llama3_8b_instruct_qlora_alpaca_e3_M_ruozhi_scM.py)    |[OpenXLab](https://openxlab.org.cn/models/detail/chg0901/EmoLLM-Llama3-8B-Instruct3.0), [ModelScope](https://modelscope.cn/models/chg0901/EmoLLM-Llama3-8B-Instruct3.0/summary) |
+|  Baichuan2_13B_chat   |  QLoRA   |   [baichuan2_13b_chat_qlora_alpaca_e3.py](./xtuner_config/baichuan2_13b_chat_qlora_alpaca_e3.py) | |
+|      ChatGLM3_6B      |   LoRA   |   [chatglm3_6b_lora_alpaca_e3.py](./xtuner_config/chatglm3_6b_lora_alpaca_e3.py)  | |
+| DeepSeek MoE_16B_chat |  QLoRA   |  [deepseek_moe_16b_chat_qlora_oasst1_e3.py](./xtuner_config/deepseek_moe_16b_chat_qlora_oasst1_e3.py)    | |
+| Mixtral 8x7B_instruct |  QLoRA   | [mixtral_8x7b_instruct_qlora_oasst1_e3.py](./xtuner_config/mixtral_8x7b_instruct_qlora_oasst1_e3.py)    | |
+| LLaMA3_8b_instruct    |  QLoRA   | [aiwei_llama3_8b_instruct_qlora_e3.py](./xtuner_config/aiwei_llama3_8b_instruct_qlora_e3.py) | [OpenXLab](https://openxlab.org.cn/models/detail/ajupyter/EmoLLM-LLaMA3_8b_instruct_aiwei/tree/main), [ModelScope](https://modelscope.cn/models/aJupyter/EmoLLM-LLaMA3_8b_instruct_aiwei/files) |
+| LLaMA3_8b_instruct    |  QLoRA   | [llama3_8b_instruct_qlora_alpaca_e3_M_ruozhi_scM.py](./xtuner_config/llama3_8b_instruct_qlora_alpaca_e3_M_ruozhi_scM.py)    |[OpenXLab](https://openxlab.org.cn/models/detail/chg0901/EmoLLM-Llama3-8B-Instruct3.0), [ModelScope](https://modelscope.cn/models/chg0901/EmoLLM-Llama3-8B-Instruct3.0/summary) |
 |          ……           |    ……    |                                                    ……                                                    | …… |
 
 
@@ -208,6 +209,7 @@
     - [バージョン管理](#バージョン管理)
     - [著者（順不同）](#著者順不同)
     - [著作権表示](#著作権表示)
+    - [引用](#引用)
     - [謝辞](#謝辞)
       - [関連プロジェクト](#関連プロジェクト)
       - [人々](#人々)
@@ -329,7 +331,7 @@ git clone https://github.com/SmartFlowAI/EmoLLM.git
 
 このプロジェクトはMITライセンスの下でライセンスされています。詳細については、[LICENSE](https://github.com/SmartFlowAI/EmoLLM/blob/master/LICENSE)を参照してください。
 
-### いんよう
+### 引用
 
 もしこのプロジェクトがあなたの研究や仕事の助けになれば、以下の形式で引用してください：
 


### PR DESCRIPTION
- Fix and standardize the language switcher across zh/en/jp (spacing, broken JP English link)
- Align header HTML structure (close <p>, consistent layout) in the Chinese README
- Sync table wording: normalize JP type column to QLoRA/LoRA; add the missing InternLM2_5_7B_chat full fine-tuning (V3.0) row in the JP model table
- Add missing sections/TOC entries: 版本控制 (zh), Citation (en), 引用 (jp)
- Fix Japanese heading typo いんよう -> 引用